### PR TITLE
added _alt + _first + _last placeholders (from rowboat)

### DIFF
--- a/core/components/migx/elements/snippets/snippet.getImagelist.php
+++ b/core/components/migx/elements/snippets/snippet.getImagelist.php
@@ -109,12 +109,16 @@ if (substr($tpl, 0, 6) == "@FILE:") {
                     }
 
                     if ($key >= $offset && $idx < $limit) {
-                        $idx++;
                         $fields['idx'] = $idx;
+                        $ct = count($items);
+                        $fields['_alt'] = $idx % 2;
+                        if ($idx == 0) $fields['_first'] = true;
+                        if ($idx == $ct-1) $fields['_last'] = true;
                         $chunk = $modx->newObject('modChunk');
                         $chunk->setCacheable(false);
                         $chunk->setContent($template);
                         $output .= $chunk->process($fields);
+                        $idx++;
                     }
 
                 }


### PR DESCRIPTION
Took some useful placeholders from Rowboat extra, which allow easier templating
example:

```
<div[[_first:is=``:then=` class="first"`]]>[[+someplaceholder]]</div>
```

Also, idx now starts at 0, since it's no more incremented from the beginning
