### PR TITLE
htmlentities & French translation

### DIFF
--- a/core/components/migx/elements/tv/input/migx.php
+++ b/core/components/migx/elements/tv/input/migx.php
@@ -81,7 +81,7 @@ if (is_array($columns) && count($columns) > 0) {
         $field['mapping'] = $column['dataIndex'];
         $fields[] = $field;
         $col['dataIndex'] = $column['dataIndex'];
-        $col['header'] = htmlentities($column['header'], ENT_QUOTES);
+        $col['header'] = htmlentities($column['header'], ENT_QUOTES, $modx->getOption('modx_charset'));
         $col['sortable'] = $column['sortable'] == 'true' ? true : false;
         $col['width'] = $column['width'];
         $col['renderer'] = $column['renderer'];

--- a/core/components/migx/lexicon/fr/default.inc.php
+++ b/core/components/migx/lexicon/fr/default.inc.php
@@ -3,7 +3,7 @@
  * migx
  *
  * @package migx
- * @language en
+ * @language fr
  */
 
 //$_lang['mig_'] = '';
@@ -15,4 +15,4 @@ $_lang['mig_remove_confirm'] = 'Êtes-vous sûr de vouloir supprimer cet éléme
 $_lang['mig_edit'] = 'Éditer';
 $_lang['mig_remove'] = 'Supprimer';
 $_lang['mig_duplicate'] = 'Dupliquer';
-$_lang['mig_preview'] = 'Preview';
+$_lang['mig_preview'] = 'Aperçu';

--- a/core/components/migx/lexicon/fr/tvprops.inc.php
+++ b/core/components/migx/lexicon/fr/tvprops.inc.php
@@ -3,12 +3,12 @@
  * migx
  *
  * @package migx
- * @language en
+ * @language fr
  */
 
 
 $_lang['mig.tabs'] = 'Onglets du formulaire';
 $_lang['mig.columns'] = 'Colonnes de la grille';
 $_lang['mig.btntext'] = 'Intitulé du bouton';
-$_lang['mig.previewurl'] = 'Preview Url';
-$_lang['mig.jsonvarkey'] = 'Preview JsonVarKey';
+$_lang['mig.previewurl'] = 'Url de prévisualisation';
+$_lang['mig.jsonvarkey'] = 'Clé de prévisualisation (JsonVarKey)';

--- a/core/components/migx/processors/mgr/fields.php
+++ b/core/components/migx/processors/mgr/fields.php
@@ -94,9 +94,9 @@ foreach ($formtabs as $tabid => $tab) {
             $record[$field['field']];
 
         $tv->set('value', $fieldvalue);
-        $tv->set('caption', htmlentities($field['caption'], ENT_QUOTES));
+        $tv->set('caption', htmlentities($field['caption'], ENT_QUOTES, $modx->getOption('modx_charset')));
         if (!empty($field['description'])) {
-            $tv->set('description', htmlentities($field['description'], ENT_QUOTES));
+            $tv->set('description', htmlentities($field['description'], ENT_QUOTES, $modx->getOption('modx_charset')));
         }
         /*generate unique tvid, must be numeric*/
         /*todo: find a better solution*/


### PR DESCRIPTION
Making sure htmlentities uses modx_charset to prevent weird character rendering + French translation of the new strings added in 1.1.0
