### PR TITLE
Problem with getImageList-Snippet when $modx->resource is not an modElement-Class (not loaded)

### DIFF
--- a/core/components/migx/elements/snippets/snippet.getImagelist.php
+++ b/core/components/migx/elements/snippets/snippet.getImagelist.php
@@ -55,7 +55,7 @@ $jsonVarKey = $modx->getOption('jsonVarKey', $scriptProperties, 'migx_outputvalu
 $outputvalue = $modx->getOption('value', $scriptProperties, '');
 $outputvalue = isset($_REQUEST[$jsonVarKey]) ? $_REQUEST[$jsonVarKey] : $outputvalue;
 $docidVarKey = $modx->getOption('docidVarKey', $scriptProperties, 'migx_docid');
-$docid = $modx->getOption('docid', $scriptProperties, $modx->resource->get('id'));
+$docid = $modx->getOption('docid', $scriptProperties, (isset($modx->resource) ? $modx->resource->get('id') : 1));
 $docid = isset($_REQUEST[$docidVarKey]) ? $_REQUEST[$docidVarKey] : $docid;
 $processTVs = $modx->getOption('processTVs', $scriptProperties, '1');
 


### PR DESCRIPTION
$modx->resource->get() is dying silently when no resource is loaded (eg: when using getImageList in a cron-job).
