### PR TITLE
Enabling Save button on Remove/Duplicate/Reorder Grid

### DIFF
--- a/core/components/migx/elements/tv/migx.tpl
+++ b/core/components/migx/elements/tv/migx.tpl
@@ -65,6 +65,7 @@ MODx.grid.multiTVgrid = function(config) {
      							ds.insert(cindex,data.selections);
                                 sm.clearSelections();
                              }
+                             MODx.fireResourceFormChange();
                          }
 						grid.collectItems();
                         grid.getView().refresh();
@@ -188,7 +189,8 @@ Ext.extend(MODx.grid.multiTVgrid,MODx.grid.LocalGrid,{
             if (e == 'yes') {
 				_this.getStore().removeAt(_this.menu.recordIndex);
                 _this.getView().refresh();
-		        _this.collectItems();	
+		        _this.collectItems();
+                MODx.fireResourceFormChange();	
                 }
             }),this;		
 	}   
@@ -196,6 +198,7 @@ Ext.extend(MODx.grid.multiTVgrid,MODx.grid.LocalGrid,{
       this.loadWin(btn,e,this.menu.recordIndex,'u');
     }
 	,duplicate: function(btn,e) {
+      MODx.fireResourceFormChange();
       this.loadWin(btn,e,this.menu.recordIndex,'d');
     }    
 	,loadWin: function(btn,e,index,action) {


### PR DESCRIPTION
Hey Bruno17,

First of all, thank you for creating MIGX, it's a really great TV!

This is related to this issue : https://github.com/Bruno17/multiItemsGridTV/issues/20

I've just updated the migx.tpl so that the event to enable the Save button is called when you reorder the grid with drag + drop and when you remove or duplicate a grid item.

For duplicating, there may be a better place to call this. Currently we are firing it right before the duplicate window opens, but it may be better to fire it on save.

Please let me know if you have any questions or ideas on how to better handle this.

Thanks,
Jude Reid
jude@butter.com.hk
Digital Butter (http://www.butter.com.hk/)
