### PR TITLE
adding "docid" tpl-placeholder in getImageList snippet

### DIFF
--- a/core/components/migx/elements/snippets/snippet.getImagelist.php
+++ b/core/components/migx/elements/snippets/snippet.getImagelist.php
@@ -258,6 +258,7 @@ if (count($items) > 0) {
     foreach ($items as $key => $item) {
 
         $fields = array();
+		$fields['docid'] = $docid;
         foreach ($item as $field => $value) {
             $value = is_array($value) ? implode('||', $value) : $value; //handle arrays (checkboxes, multiselects)
             if ($processTVs && isset($inputTvs[$field])) {


### PR DESCRIPTION
useful for output like this
&lt;span &gt;[[+title]] &lt;a href="[[++base_url]][[~[[+docid]]]]" class="more" &gt;read more&lt;/a &gt;&lt;/span &gt;
